### PR TITLE
Add pseudo class support

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,5 @@
 const cssToObject = require('css-to-object')
 
-// todo: merge pseudoclass rules
-
 const hyph = s => s.replace(/[A-Z]|^ms/g, '-$&').toLowerCase()
 
 const createDeclarations = obj => Object.keys(obj)
@@ -12,7 +10,7 @@ const createDeclarations = obj => Object.keys(obj)
 const parser = css => {
   const obj = cssToObject(css)
 
-  return Object.keys(obj)
+  const parsed = Object.keys(obj)
     .filter(key => /^[@.]/.test(key))
     .map(key => ({
       key,
@@ -38,6 +36,19 @@ const parser = css => {
       ...(Array.isArray(b) ? b : [ b ])
     ], [])
     .reduce((a, b) => Object.assign(a, { [b.key]: [b.value] }), {})
+
+  const isPseudoClass = k => /:{1,2}(.*)$/.test(k)
+  const getBaseClass = k => k.split(/:{1,2}(.*)$/)[0]
+
+  Object.keys(parsed)
+    .filter(isPseudoClass)
+    .forEach(pseudo => {
+      const baseClass = getBaseClass(pseudo)
+      parsed[baseClass] = (parsed[baseClass] || []).concat(parsed[pseudo])
+      delete parsed[pseudo]
+    })
+
+  return parsed
 }
 
 module.exports = parser

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,0 +1,43 @@
+const cssToObject = require('css-to-object')
+
+// todo: merge pseudoclass rules
+
+const hyph = s => s.replace(/[A-Z]|^ms/g, '-$&').toLowerCase()
+
+const createDeclarations = obj => Object.keys(obj)
+  .map(prop => {
+    return hyph(prop) + ':' + obj[prop]
+  }).join(';')
+
+const parser = css => {
+  const obj = cssToObject(css)
+
+  return Object.keys(obj)
+    .filter(key => /^[@.]/.test(key))
+    .map(key => ({
+      key,
+      value: obj[key]
+    }))
+    .map(({ key, value }) => {
+      if (/^@/.test(key)) {
+        return Object.keys(value).map(k => {
+          return {
+            key: k.replace(/^\./, ''),
+            value: key + '{' + k + '{' + createDeclarations(value[k]) + '}}'
+          }
+        })
+      }
+      return {
+        key: key.replace(/^\./, ''),
+        value: key + '{' + createDeclarations(value) + '}'
+      }
+    })
+    // flatten
+    .reduce((a, b) => [
+      ...a,
+      ...(Array.isArray(b) ? b : [ b ])
+    ], [])
+    .reduce((a, b) => Object.assign(a, { [b.key]: [b.value] }), {})
+}
+
+module.exports = parser

--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -1,49 +1,14 @@
 const fs = require('fs')
 const path = require('path')
-const cssToObject = require('css-to-object')
+const parser = require('../lib/parser')
 
 // todo: make this work for basscss too
-// todo: merge pseudoclass rules
 
 const filepath = path.join(__dirname, '..', 'node_modules/tachyons/css/tachyons.css')
 
 const css = fs.readFileSync(filepath, 'utf8')
 
-const obj = cssToObject(css)
-
-const hyph = s => s.replace(/[A-Z]|^ms/g, '-$&').toLowerCase()
-
-const createDeclarations = obj => Object.keys(obj)
-  .map(prop => {
-    return hyph(prop) + ':' + obj[prop]
-  }).join(';')
-
-const parsed = Object.keys(obj)
-  .filter(key => /^[@.]/.test(key))
-  .map(key => ({
-    key,
-    value: obj[key]
-  }))
-  .map(({ key, value }) => {
-    if (/^@/.test(key)) {
-      return Object.keys(value).map(k => {
-        return {
-          key: k.replace(/^\./, ''),
-          value: key + '{' + k + '{' + createDeclarations(value[k]) + '}}'
-        }
-      })
-    }
-    return {
-      key: key.replace(/^\./, ''),
-      value: key + '{' + createDeclarations(value) + '}'
-    }
-  })
-  // flatten
-  .reduce((a, b) => [
-    ...a,
-    ...(Array.isArray(b) ? b : [ b ])
-  ], [])
-  .reduce((a, b) => Object.assign(a, { [b.key]: [b.value] }), {})
+const parsed = parser(css)
 
 const json = JSON.stringify(parsed, null, 2)
 

--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -43,7 +43,7 @@ const parsed = Object.keys(obj)
     ...a,
     ...(Array.isArray(b) ? b : [ b ])
   ], [])
-  .reduce((a, b) => Object.assign(a, { [b.key]: b.value }), {})
+  .reduce((a, b) => Object.assign(a, { [b.key]: [b.value] }), {})
 
 const json = JSON.stringify(parsed, null, 2)
 

--- a/src/css.js
+++ b/src/css.js
@@ -2,10 +2,12 @@ let cache = {}
 const rules = []
 let insert = rule => rules.push(rule)
 
-const css = rule => {
-  if (cache[rule]) return
-  insert(rule)
-  cache[rule] = true
+const css = rs => {
+  rs.forEach(rule => {
+    if (cache[rule]) return
+    insert(rule)
+    cache[rule] = true
+  })
 }
 
 css.css = () => rules.join('')

--- a/test/css.js
+++ b/test/css.js
@@ -6,19 +6,24 @@ test.afterEach.always(() => {
 })
 
 test('css adds rules', t => {
-  css('.tomato{color:tomato}')
+  css(['.tomato{color:tomato}'])
   t.is(typeof css.css(), 'string')
   t.is(css.css(), '.tomato{color:tomato}')
 })
 
+test('css adds multiple rules', t => {
+  css(['.tomato{color:tomato}', '.tomato:hover{color:orange}'])
+  t.is(css.css(), '.tomato{color:tomato}.tomato:hover{color:orange}')
+})
+
 test('css dedupes', t => {
-  css('.tomato{color:tomato}')
-  css('.tomato{color:tomato}')
+  css(['.tomato{color:tomato}'])
+  css(['.tomato{color:tomato}'])
   t.is(css.css(), '.tomato{color:tomato}')
 })
 
 test('css resets', t => {
-  css('.tomato{color:tomato}')
+  css(['.tomato{color:tomato}'])
   css.reset()
   t.is(css.css(), '')
 })

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,0 +1,16 @@
+import test from 'ava'
+import parser from '../lib/parser'
+
+test('parses rules', t => {
+  const css = '.tomato{color:tomato}'
+  t.deepEqual(parser(css), {
+    tomato: ['.tomato{color:tomato}']
+  })
+})
+
+test('parses media queries', t => {
+  const css = '@media screen and (min-width: 30em){.aspect-ratio-ns{height:0;position:relative}}'
+  t.deepEqual(parser(css), {
+    'aspect-ratio-ns': ['@media screen and (min-width: 30em){.aspect-ratio-ns{height:0;position:relative}}']
+  })
+})

--- a/test/parser.js
+++ b/test/parser.js
@@ -14,3 +14,12 @@ test('parses media queries', t => {
     'aspect-ratio-ns': ['@media screen and (min-width: 30em){.aspect-ratio-ns{height:0;position:relative}}']
   })
 })
+
+test('parses pseudo classes', t => {
+  const css = '.tomato{color:tomato}.tomato:hover{color:orange}.cucumber:focus{color:green}.shadow::after{color:red}'
+  t.deepEqual(parser(css), {
+    tomato: ['.tomato{color:tomato}', '.tomato:hover{color:orange}'],
+    cucumber: ['.cucumber:focus{color:green}'],
+    shadow: ['.shadow::after{color:red}']
+  })
+})


### PR DESCRIPTION
Closes #2.

This is best reviewed commit by commit.

I've changed the parser to serialise rules into arrays because `insertRule` wants individual CSS blocks. This has the side effect of making `tachyons.json` also a bit more readable.

There are still some classes which don't work with this, ones with nested children, I'll open another issue (https://github.com/jxnblk/tachyons-components/issues/4) and open another PR, but wanted to get this across for feedback. :)

Also just wanted to say you do amazing work @jxnblk, I can't wait to use this.