### PR TITLE
Fix to support template tokens that return more than one class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 coverage
 .nyc_output
 tachyons.json
+node_modules/

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const styled = type => (strings, ...tokens) => {
       .map(token => token(props))
       .filter(n => n !== null && n !== undefined)
       .map(n => n.split(/\s+/))
+      .reduce((a, b) => [ ...a, ...b ], [])
     keys.map(key => dict[key])
       .filter(n => n !== undefined)
       .forEach(css)

--- a/test/index.js
+++ b/test/index.js
@@ -37,3 +37,13 @@ test('handles template tokens', t => {
   t.is(a.props.className, '')
   t.is(b.props.className, 'bg-blue')
 })
+
+test('handles template tokens when more than one class returned', t => {
+  const A = styled('div')`
+    ${props => props.foo ? 'bg-blue grow' : null}
+  `
+  const a = render(<A />).toJSON()
+  const b = render(<A foo />).toJSON()
+  t.is(a.props.className, '')
+  t.is(b.props.className, 'bg-blue grow')
+})


### PR DESCRIPTION
Without this additional reduce to flatten the array returned by each template token the class output is `"bg-blue,grow"` if more than one class is returned. 

Includes test case and update to ignore node_modules.