### PR TITLE
Add support for multiple classes in computed properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,7 @@ const h = require('react').createElement
 const css = require('./css')
 const dict = require('../tachyons.json')
 
-const flatten = arr =>
-  arr.reduce(
-    (acc, val) =>
-      Array.isArray(val) ? [...acc, ...flatten(val)] : [...acc, val],
-    []
-  )
+const concat = (a, b) => a.concat(b)
 
 const styled = type => (strings, ...tokens) => {
   const staticKeys = strings
@@ -19,12 +14,11 @@ const styled = type => (strings, ...tokens) => {
     .forEach(css)
 
   const Component = props => {
-    const keys = flatten(
-      tokens
+    const keys = tokens
       .map(token => token(props))
       .filter(n => n !== null && n !== undefined)
       .map(n => n.split(/\s+/))
-    )
+      .reduce(concat, [])
     keys.map(key => dict[key])
       .filter(n => n !== undefined)
       .forEach(css)

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,13 @@ const h = require('react').createElement
 const css = require('./css')
 const dict = require('../tachyons.json')
 
+const flatten = arr =>
+  arr.reduce(
+    (acc, val) =>
+      Array.isArray(val) ? [...acc, ...flatten(val)] : [...acc, val],
+    []
+  )
+
 const styled = type => (strings, ...tokens) => {
   const staticKeys = strings
     .map(str => str.split(/\s+/))
@@ -12,10 +19,12 @@ const styled = type => (strings, ...tokens) => {
     .forEach(css)
 
   const Component = props => {
-    const keys = tokens
+    const keys = flatten(
+      tokens
       .map(token => token(props))
       .filter(n => n !== null && n !== undefined)
       .map(n => n.split(/\s+/))
+    )
     keys.map(key => dict[key])
       .filter(n => n !== undefined)
       .forEach(css)


### PR DESCRIPTION
### The Issue
Adding multiple tachyons classes like this:
```javascript
export const Link = styled('a')`
  blue
  f6
  no-underline
  ${props => props.nav ? 'fw4 mb2' : ''}
`
```

The output would be comma separated in the render 
```html
<a class="blue f6 no-underline fw4,mb2">My Link</a>
```

### The Solution
This was happening because we have to split each function token which results in nested array. So the solution is to flatten the nested arrays and it works.

Let me know if I should open a corresponding issue before this will be considered! Thanks!